### PR TITLE
Migrate to Metro for web and fix navigation

### DIFF
--- a/app.json
+++ b/app.json
@@ -33,8 +33,5 @@
         "backgroundColor": "#ffffff"
       }
     },
-    "web": {
-      "favicon": "./assets/favicon.png"
-    }
   }
 }

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,0 +1,5 @@
+const { getDefaultConfig } = require('expo/metro-config');
+
+const config = getDefaultConfig(__dirname);
+
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@expo/webpack-config": "^19.0.0",
     "@fortawesome/fontawesome-svg-core": "^6.5.1",
     "@fortawesome/free-brands-svg-icons": "^6.5.1",
     "@fortawesome/free-regular-svg-icons": "^6.5.1",


### PR DESCRIPTION
This commit migrates the project from webpack to Metro for the web build. This was done to fix a persistent `require is not defined` error.

This commit also includes the following changes:
- Refactored the navigation to use a simple stack navigator with a test menu as the initial route.
- Redesigned the UI of all pages with a modern, minimal, pastel green theme.
- Added sample data to allow for testing the app without a backend.
- Fixed the navigation in `TestMenu.js`.
- Fixed the data display in `MainPage.js`, `CoursePage.js`, and `QuestionPage.js`.

Note: The `package-lock.json` file was deleted during the process of upgrading the Expo SDK and could not be restored because it was not tracked by git. This should be addressed in the future to ensure consistent dependency installation.